### PR TITLE
Modernize `ArraySessionStorage` in tests to use `SessionHandlerInterface`

### DIFF
--- a/tests/KdybyTests/BootstrapFormRenderer/BootstrapRendererTest.phpt
+++ b/tests/KdybyTests/BootstrapFormRenderer/BootstrapRendererTest.phpt
@@ -237,7 +237,7 @@ class BootstrapRendererTest extends TestCase
 		foreach ($form->getComponents(TRUE, 'Nette\Forms\Controls\CsrfProtection') as $control) {
 			/** @var \Nette\Forms\Controls\CsrfProtection $control */
 			$control->session = new Nette\Http\Session($form->httpRequest, new Nette\Http\Response);
-			$control->session->setStorage(new ArraySessionStorage($control->session));
+			$control->session->setHandler(new ArraySessionStorage($control->session));
 			$control->session->start();
 		}
 
@@ -314,7 +314,7 @@ class ControlMock extends Nette\Application\UI\Control
  *
  * @internal
  */
-class ArraySessionStorage extends Nette\Object implements Nette\Http\ISessionStorage
+class ArraySessionStorage implements \SessionHandlerInterface
 {
 
 	/**
@@ -334,6 +334,7 @@ class ArraySessionStorage extends Nette\Object implements Nette\Http\ISessionSto
 	public function open($savePath, $sessionName)
 	{
 		$this->session = array();
+		return true;
 	}
 
 
@@ -341,13 +342,14 @@ class ArraySessionStorage extends Nette\Object implements Nette\Http\ISessionSto
 	public function close()
 	{
 		$this->session = array();
+		return true;
 	}
 
 
 
 	public function read($id)
 	{
-		return isset($this->session[$id]) ? $this->session[$id] : NULL;
+		return isset($this->session[$id]) ? $this->session[$id] : '';
 	}
 
 
@@ -355,20 +357,22 @@ class ArraySessionStorage extends Nette\Object implements Nette\Http\ISessionSto
 	public function write($id, $data)
 	{
 		$this->session[$id] = $data;
+		return true;
 	}
 
 
 
-	public function remove($id)
+	public function destroy($id)
 	{
 		unset($this->session[$id]);
+		return true;
 	}
 
 
 
-	public function clean($maxlifetime)
+	public function gc($maxlifetime)
 	{
-
+		return true;
 	}
 
 }


### PR DESCRIPTION
Modernizes the `ArraySessionStorage` test helper class to use PHP's native `SessionHandlerInterface` instead of the deprecated Nette-specific `ISessionStorage` interface.

This change aligns the test infrastructure with:
1. PHP's standard session handler interface (`SessionHandlerInterface`)
2. Modern Nette framework API (`setHandler()` instead of `setStorage()`)
3. Current PHP best practices (avoiding deprecated `Nette\Object`)

The changes are isolated to test code only and do not affect the library's public API.