### PR TITLE
Add regression test: don't add `form-horizontal` when form already has `form-*` class

### DIFF
--- a/tests/KdybyTests/BootstrapFormRenderer/BootstrapRendererTest.phpt
+++ b/tests/KdybyTests/BootstrapFormRenderer/BootstrapRendererTest.phpt
@@ -200,6 +200,41 @@ class BootstrapRendererTest extends TestCase
 
 
 	/**
+	 * @return \Nette\Application\UI\Form
+	 */
+	private function dataCreateMinimalForm()
+	{
+		$form = new Form;
+		$form->addText('name', 'Name');
+		$form->addSubmit('send', 'Submit');
+
+		return $form;
+	}
+
+
+	/**
+	 * @return array
+	 */
+	public function dataFormStyling()
+	{
+		return array_map(function ($f) { return array(basename($f)); }, glob(__DIR__ . '/form-styling/input/*.latte'));
+	}
+
+
+
+	/**
+	 * @dataProvider dataFormStyling
+	 * @param string $latteFile
+	 */
+	public function testFormStyling($latteFile)
+	{
+		$form = $this->dataCreateMinimalForm();
+		$this->assertFormTemplateOutput(__DIR__ . '/form-styling/input/' . $latteFile, __DIR__ . '/form-styling/output/' . basename($latteFile, '.latte') . '.html', $form);
+	}
+
+
+
+	/**
 	 * @return array
 	 */
 	public function dataRenderingCheckboxList()

--- a/tests/KdybyTests/BootstrapFormRenderer/form-styling/input/form-default.latte
+++ b/tests/KdybyTests/BootstrapFormRenderer/form-styling/input/form-default.latte
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head><link href="../../bootstrap.min.css" rel="stylesheet"></head>
+<body>
+
+    <div class="container">
+    {form $form}
+    {/form}
+	</div>
+
+</body>
+</html>

--- a/tests/KdybyTests/BootstrapFormRenderer/form-styling/input/form-inline.latte
+++ b/tests/KdybyTests/BootstrapFormRenderer/form-styling/input/form-inline.latte
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head><link href="../../bootstrap.min.css" rel="stylesheet"></head>
+<body>
+
+    <div class="container">
+    {form $form class => 'form-inline'}
+    {/form}
+	</div>
+
+</body>
+</html>

--- a/tests/KdybyTests/BootstrapFormRenderer/form-styling/input/form-search.latte
+++ b/tests/KdybyTests/BootstrapFormRenderer/form-styling/input/form-search.latte
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head><link href="../../bootstrap.min.css" rel="stylesheet"></head>
+<body>
+
+    <div class="container">
+    {form $form class => 'form-search'}
+    {/form}
+	</div>
+
+</body>
+</html>

--- a/tests/KdybyTests/BootstrapFormRenderer/form-styling/output/form-default.html
+++ b/tests/KdybyTests/BootstrapFormRenderer/form-styling/output/form-default.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<link href="../../bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div class="container">
+	<form action="" method="post" class="form-horizontal">
+		<div><!--[if IE]><input type=IEbug disabled style="display:none"><![endif]--></div>
+	</form>
+</div>
+</body>
+</html>

--- a/tests/KdybyTests/BootstrapFormRenderer/form-styling/output/form-inline.html
+++ b/tests/KdybyTests/BootstrapFormRenderer/form-styling/output/form-inline.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<link href="../../bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div class="container">
+	<form action="" method="post" class="form-inline">
+		<div><!--[if IE]><input type=IEbug disabled style="display:none"><![endif]--></div>
+	</form>
+</div>
+</body>
+</html>

--- a/tests/KdybyTests/BootstrapFormRenderer/form-styling/output/form-search.html
+++ b/tests/KdybyTests/BootstrapFormRenderer/form-styling/output/form-search.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<link href="../../bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div class="container">
+	<form action="" method="post" class="form-search">
+		<div><!--[if IE]><input type=IEbug disabled style="display:none"><![endif]--></div>
+	</form>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Adds regression tests to verify that the renderer respects developer-chosen Bootstrap form type classes (`form-inline`, `form-search`) and does not add `form-horizontal` when these classes are already present.

Fixes #35