### PR TITLE
Remove translation of `placeholder` option values (#29)

### DIFF
--- a/src/Kdyby/BootstrapFormRenderer/BootstrapRenderer.php
+++ b/src/Kdyby/BootstrapFormRenderer/BootstrapRenderer.php
@@ -165,7 +165,6 @@ class BootstrapRenderer extends Nette\Object implements Nette\Forms\IFormRendere
 	 */
 	private function prepareControl(Controls\BaseControl $control)
 	{
-		$translator = $this->form->getTranslator();
 		$control->setOption('rendered', FALSE);
 
 		if ($control->isRequired()) {
@@ -175,9 +174,6 @@ class BootstrapRenderer extends Nette\Object implements Nette\Forms\IFormRendere
 
 		$el = $control->getControlPrototype();
 		if ($placeholder = $control->getOption('placeholder')) {
-			if (!$placeholder instanceof Html && $translator) {
-				$placeholder = $translator->translate($placeholder);
-			}
 			$el->placeholder($placeholder);
 		}
 

--- a/tests/KdybyTests/BootstrapFormRenderer/BootstrapRendererTest.phpt
+++ b/tests/KdybyTests/BootstrapFormRenderer/BootstrapRendererTest.phpt
@@ -319,6 +319,75 @@ class BootstrapRendererTest extends TestCase
 
 
 	/**
+	 * @param bool $withTranslator
+	 * @return \Nette\Application\UI\Form
+	 */
+	private function dataCreatePlaceholderForm($withTranslator = FALSE)
+	{
+		$form = new Form;
+		if ($withTranslator) {
+			$form->setTranslator(new DummyTranslator());
+		}
+
+		$form->addText('email', 'Email')
+			->setType('email')
+			->setOption('placeholder', 'Enter your email');
+		$form->addText('name', 'Name')
+			->setOption('placeholder', 'Enter your name');
+		$form->addTextArea('message', 'Message')
+			->setOption('placeholder', 'Type your message here');
+		$form->addSubmit('send', 'Submit');
+
+		return $form;
+	}
+
+
+
+	/**
+	 * @return array
+	 */
+	public function dataRenderingPlaceholder()
+	{
+		return array_map(function ($f) { return array(basename($f)); }, glob(__DIR__ . '/placeholder/input/*.latte'));
+	}
+
+
+
+	/**
+	 * @dataProvider dataRenderingPlaceholder
+	 * @param string $latteFile
+	 */
+	public function testRenderingPlaceholder($latteFile)
+	{
+		$form = $this->dataCreatePlaceholderForm();
+		$this->assertFormTemplateOutput(__DIR__ . '/placeholder/input/' . $latteFile, __DIR__ . '/placeholder/output/' . basename($latteFile, '.latte') . '.html', $form);
+	}
+
+
+
+	/**
+	 * @return array
+	 */
+	public function dataRenderingPlaceholderWithTranslator()
+	{
+		return array_map(function ($f) { return array(basename($f)); }, glob(__DIR__ . '/placeholder-translated/input/*.latte'));
+	}
+
+
+
+	/**
+	 * @dataProvider dataRenderingPlaceholderWithTranslator
+	 * @param string $latteFile
+	 */
+	public function testRenderingPlaceholderWithTranslator($latteFile)
+	{
+		$form = $this->dataCreatePlaceholderForm(TRUE);
+		$this->assertFormTemplateOutput(__DIR__ . '/placeholder-translated/input/' . $latteFile, __DIR__ . '/placeholder-translated/output/' . basename($latteFile, '.latte') . '.html', $form);
+	}
+
+
+
+	/**
 	 * @param $latteFile
 	 * @param $expectedOutput
 	 * @param \Nette\Application\UI\Form $form
@@ -473,6 +542,48 @@ class ArraySessionStorage implements \SessionHandlerInterface
 	public function gc($maxlifetime)
 	{
 		return true;
+	}
+
+}
+
+/**
+ * Simple translator for testing placeholder translation
+ * Translates English form labels and placeholders to Slovak
+ * @author Claude Code
+ */
+class DummyTranslator implements Nette\Localization\ITranslator
+{
+
+	/**
+	 * Translation table for English to Slovak
+	 * @var array
+	 */
+	private $translations = array(
+		'Email' => 'E-mail',
+		'Name' => 'Meno',
+		'Message' => 'Správa',
+		'Submit' => 'Odoslať',
+		'Enter your email' => 'Zadajte váš e-mail',
+		'Enter your name' => 'Zadajte vaše meno',
+		'Type your message here' => 'Napíšte svoju správu',
+	);
+
+	/**
+	 * Translates the given string to Slovak
+	 *
+	 * @param string $message
+	 * @param int $count
+	 * @return string
+	 */
+	public function translate($message, $count = NULL)
+	{
+		if (isset($this->translations[$message])) {
+			return $this->translations[$message];
+		}
+
+		// return modified string to indicate missing translation
+		// this helps to identify double translations in code
+		return "MISSING_TRANSLATION: $message";
 	}
 
 }

--- a/tests/KdybyTests/BootstrapFormRenderer/placeholder-translated/input/email.latte
+++ b/tests/KdybyTests/BootstrapFormRenderer/placeholder-translated/input/email.latte
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head><link href="../../bootstrap.min.css" rel="stylesheet"></head>
+<body>
+
+    <div class="container">
+        {$form->render('begin')}
+        {$form->render($form['email'])}
+        {$form->render('end')}
+	</div>
+
+</body>
+</html>

--- a/tests/KdybyTests/BootstrapFormRenderer/placeholder-translated/input/name.latte
+++ b/tests/KdybyTests/BootstrapFormRenderer/placeholder-translated/input/name.latte
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head><link href="../../bootstrap.min.css" rel="stylesheet"></head>
+<body>
+
+    <div class="container">
+        {$form->render('begin')}
+        {$form->render($form['name'])}
+        {$form->render('end')}
+	</div>
+
+</body>
+</html>

--- a/tests/KdybyTests/BootstrapFormRenderer/placeholder-translated/input/textarea.latte
+++ b/tests/KdybyTests/BootstrapFormRenderer/placeholder-translated/input/textarea.latte
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head><link href="../../bootstrap.min.css" rel="stylesheet"></head>
+<body>
+
+    <div class="container">
+        {$form->render('begin')}
+        {$form->render($form['message'])}
+        {$form->render('end')}
+	</div>
+
+</body>
+</html>

--- a/tests/KdybyTests/BootstrapFormRenderer/placeholder-translated/output/email.html
+++ b/tests/KdybyTests/BootstrapFormRenderer/placeholder-translated/output/email.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<link href="../../bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div class="container">
+	<form action="" method="post" class="form-horizontal">
+		<div id="frm-foo-email-pair" class="control-group">
+			<label class="control-label" for="frm-foo-email">E-mail</label>
+
+			<div class="controls">
+				<div class="input-prepend">
+					<span class="add-on">@</span>
+					<input type="email" name="email" placeholder="Zadajte váš e-mail" id="frm-foo-email" value="">
+				</div>
+			</div>
+		</div>
+	</form>
+</div>
+</body>
+</html>

--- a/tests/KdybyTests/BootstrapFormRenderer/placeholder-translated/output/name.html
+++ b/tests/KdybyTests/BootstrapFormRenderer/placeholder-translated/output/name.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<link href="../../bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div class="container">
+	<form action="" method="post" class="form-horizontal">
+		<div id="frm-foo-name-pair" class="control-group">
+			<label class="control-label" for="frm-foo-name">Meno</label>
+
+			<div class="controls">
+				<input type="text" name="name" placeholder="Zadajte vaše meno" id="frm-foo-name" value="">
+			</div>
+		</div>
+	</form>
+</div>
+</body>
+</html>

--- a/tests/KdybyTests/BootstrapFormRenderer/placeholder-translated/output/textarea.html
+++ b/tests/KdybyTests/BootstrapFormRenderer/placeholder-translated/output/textarea.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<link href="../../bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div class="container">
+	<form action="" method="post" class="form-horizontal">
+		<div id="frm-foo-message-pair" class="control-group">
+			<label class="control-label" for="frm-foo-message">Správa</label>
+
+			<div class="controls">
+				<textarea name="message" placeholder="Napíšte svoju správu" id="frm-foo-message"></textarea>
+			</div>
+		</div>
+	</form>
+</div>
+</body>
+</html>

--- a/tests/KdybyTests/BootstrapFormRenderer/placeholder/input/email.latte
+++ b/tests/KdybyTests/BootstrapFormRenderer/placeholder/input/email.latte
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head><link href="../../bootstrap.min.css" rel="stylesheet"></head>
+<body>
+
+    <div class="container">
+        {$form->render('begin')}
+        {$form->render($form['email'])}
+        {$form->render('end')}
+	</div>
+
+</body>
+</html>

--- a/tests/KdybyTests/BootstrapFormRenderer/placeholder/input/name.latte
+++ b/tests/KdybyTests/BootstrapFormRenderer/placeholder/input/name.latte
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head><link href="../../bootstrap.min.css" rel="stylesheet"></head>
+<body>
+
+    <div class="container">
+        {$form->render('begin')}
+        {$form->render($form['name'])}
+        {$form->render('end')}
+	</div>
+
+</body>
+</html>

--- a/tests/KdybyTests/BootstrapFormRenderer/placeholder/input/textarea.latte
+++ b/tests/KdybyTests/BootstrapFormRenderer/placeholder/input/textarea.latte
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head><link href="../../bootstrap.min.css" rel="stylesheet"></head>
+<body>
+
+    <div class="container">
+        {$form->render('begin')}
+        {$form->render($form['message'])}
+        {$form->render('end')}
+	</div>
+
+</body>
+</html>

--- a/tests/KdybyTests/BootstrapFormRenderer/placeholder/output/email.html
+++ b/tests/KdybyTests/BootstrapFormRenderer/placeholder/output/email.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<link href="../../bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div class="container">
+	<form action="" method="post" class="form-horizontal">
+		<div id="frm-foo-email-pair" class="control-group">
+			<label class="control-label" for="frm-foo-email">Email</label>
+
+			<div class="controls">
+				<div class="input-prepend">
+					<span class="add-on">@</span>
+					<input type="email" name="email" placeholder="Enter your email" id="frm-foo-email" value="">
+				</div>
+			</div>
+		</div>
+	</form>
+</div>
+</body>
+</html>

--- a/tests/KdybyTests/BootstrapFormRenderer/placeholder/output/name.html
+++ b/tests/KdybyTests/BootstrapFormRenderer/placeholder/output/name.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<link href="../../bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div class="container">
+	<form action="" method="post" class="form-horizontal">
+		<div id="frm-foo-name-pair" class="control-group">
+			<label class="control-label" for="frm-foo-name">Name</label>
+
+			<div class="controls">
+				<input type="text" name="name" placeholder="Enter your name" id="frm-foo-name" value="">
+			</div>
+		</div>
+	</form>
+</div>
+</body>
+</html>

--- a/tests/KdybyTests/BootstrapFormRenderer/placeholder/output/textarea.html
+++ b/tests/KdybyTests/BootstrapFormRenderer/placeholder/output/textarea.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<link href="../../bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div class="container">
+	<form action="" method="post" class="form-horizontal">
+		<div id="frm-foo-message-pair" class="control-group">
+			<label class="control-label" for="frm-foo-message">Message</label>
+
+			<div class="controls">
+				<textarea name="message" placeholder="Type your message here" id="frm-foo-message"></textarea>
+			</div>
+		</div>
+	</form>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Nette 2.1 already translates the HTML `placeholder` attribute for text-based controls


Fixes #29