### PR TITLE
Drop `Nette\Bridges\FormsLatte\FormMacros` aliasing (#43)

### DIFF
--- a/src/Kdyby/BootstrapFormRenderer/BootstrapRenderer.php
+++ b/src/Kdyby/BootstrapFormRenderer/BootstrapRenderer.php
@@ -13,14 +13,9 @@ namespace Kdyby\BootstrapFormRenderer;
 use Nette;
 use Nette\Forms\Controls;
 use Nette\Iterators\Filter;
-use Nette\Bridges\FormsLatte\FormMacros;
+use Nette\Latte\Macros\FormMacros;
 use Nette\Templating\FileTemplate;
 use Nette\Utils\Html;
-
-
-if (!class_exists('Nette\Bridges\FormsLatte\FormMacros')) {
-	class_alias('Nette\Latte\Macros\FormMacros', 'Nette\Bridges\FormsLatte\FormMacros');
-}
 
 
 /**

--- a/src/Kdyby/BootstrapFormRenderer/Latte/FormMacros.php
+++ b/src/Kdyby/BootstrapFormRenderer/Latte/FormMacros.php
@@ -19,11 +19,6 @@ use Nette\Latte\PhpWriter;
 use Nette\Reflection\ClassType;
 
 
-if (!class_exists('Nette\Bridges\FormsLatte\FormMacros')) {
-	class_alias('Nette\Latte\Macros\FormMacros', 'Nette\Bridges\FormsLatte\FormMacros');
-}
-
-
 /**
  * Standard macros:
  * <code>
@@ -136,7 +131,7 @@ class FormMacros extends Latte\Macros\MacroSet
 			return '';
 		}
 
-		return $writer->write('Nette\Bridges\FormsLatte\FormMacros::renderFormEnd($__form)');
+		return $writer->write('Nette\Latte\Macros\FormMacros::renderFormEnd($__form)');
 	}
 
 
@@ -213,7 +208,7 @@ class FormMacros extends Latte\Macros\MacroSet
 			$form->render('begin', $args);
 
 		} else {
-			Nette\Bridges\FormsLatte\FormMacros::renderFormBegin($form, $args);
+			Nette\Latte\Macros\FormMacros::renderFormBegin($form, $args);
 		}
 	}
 


### PR DESCRIPTION
Replace all imports and usages of `Nette\Bridges\FormsLatte\FormMacros` with `Nette\Latte\Macros\FormMacros`, the correct namespace for Nette 2.1.

Remove `class_alias` compatibility shims that were supporting the bridge namespace, which is not part of the Nette 2.1 framwork.

Fixes #43