### PR TITLE
Add test for `priorGroups` which controls group render ordering

### DIFF
--- a/tests/KdybyTests/BootstrapFormRenderer/group-ordering/input/body.latte
+++ b/tests/KdybyTests/BootstrapFormRenderer/group-ordering/input/body.latte
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head><link href="../../bootstrap.min.css" rel="stylesheet"></head>
+<body>
+
+    <div class="container">
+    {$form->render('body')}
+	</div>
+
+</body>
+</html>

--- a/tests/KdybyTests/BootstrapFormRenderer/group-ordering/output/body.html
+++ b/tests/KdybyTests/BootstrapFormRenderer/group-ordering/output/body.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<link href="../../bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div class="container">
+	<fieldset>
+		<legend>Group B</legend>
+		<div id="frm-foo-fieldB-pair" class="control-group">
+			<label class="control-label" for="frm-foo-fieldB">Field B</label>
+
+			<div class="controls">
+				<input type="text" name="fieldB" id="frm-foo-fieldB" value="">
+			</div>
+		</div>
+	</fieldset>
+	<fieldset>
+		<legend>Group A</legend>
+		<div id="frm-foo-fieldA-pair" class="control-group">
+			<label class="control-label" for="frm-foo-fieldA">Field A</label>
+
+			<div class="controls">
+				<input type="text" name="fieldA" id="frm-foo-fieldA" value="">
+			</div>
+		</div>
+	</fieldset>
+	<div class="form-actions">
+		<input type="submit" name="send" class="btn" id="frm-foo-send" value="Submit">
+	</div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
The `BootstrapRenderer` supports explicit group ordering via `BootstrapRenderer::$priorGroups`.

This adds a dedicated test with a form containing two visible groups (A and B), where the renderer is configured with `priorGroups = ['B']`. The golden output verifies that group B's fieldset appears before group A's fieldset, locking in the deterministic ordering behavior.


Fixes #31 