### PR TITLE
Use composer scripts to run tests and lint the code

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,13 +30,13 @@ jobs:
       run: composer install --no-interaction --prefer-source --dev
 
     - name: Run parallel-lint
-      run: ./vendor/bin/parallel-lint -e php,phpt --exclude vendor .
+      run: composer lint
 
     - name: Tester environment
-      run: ./vendor/bin/tester -c ./tests/php-tests.ini ./tests/KdybyTests/ --info
+      run: composer test:info
 
     - name: Run tests
-      run: ./vendor/bin/tester -c ./tests/php-tests.ini -o junit ./tests/KdybyTests/ > ./test-results.xml
+      run: composer test:junit > ./test-results.xml
 
     - name: Display test failures
       if: failure()

--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,15 @@
 		"psr-0": {
 			"Kdyby\\BootstrapFormRenderer\\": "src/"
 		}
+	},
+	"scripts": {
+		"lint": "parallel-lint -e php,phpt --exclude vendor .",
+		"test": "tester -c ./tests/php-tests.ini ./tests/KdybyTests/",
+		"test:info": "tester -c ./tests/php-tests.ini ./tests/KdybyTests/ --info",
+		"test:junit": "tester -c ./tests/php-tests.ini -o junit ./tests/KdybyTests/",
+		"check": [
+			"@lint",
+			"@test"
+		]
 	}
 }


### PR DESCRIPTION
- `composer lint` - Runs PHP parallel-lint to check for syntax errors across the codebase
- `composer test` - Runs the full test suite with Nette Tester
- `composer test:info` - Runs tests with info output (useful for seeing test environment details)
- `composer test:junit` - Runs tests with JUnit output format
- `composer check` - Runs both lint and test in sequence (convenient for pre-commit checks)