### PR TITLE
Align `{form name /}` with Latte 2.1 semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,17 +173,27 @@ The simplest way to render a complete form with all Bootstrap styling:
 {control contactForm}
 ```
 
-Or using the short syntax:
+### Partial Form Rendering
+
+For more control over the form layout, you can render individual parts:
+
+#### Opening and Closing Tags Only
+
+To render just the form's opening `<form>` and closing `</form>` tags (without any form body), use the self-closing syntax:
 
 ```latte
 {form contactForm /}
 ```
 
-### Partial Form Rendering
+This is equivalent to:
 
-For more control over the form layout, you can render individual parts:
+```latte
+{form contactForm}{/form}
+```
 
-#### Opening Tag
+Both render only the begin and end tags, following standard Latte 2.1 semantics. Use this when you want to manually render form content or integrate with other components.
+
+#### Opening Tag with Custom Content
 
 ```latte
 {form contactForm}

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v2.1.2
+
+### Breaking Changes
+
+#### Form Macros - Latte 2.1 Semantics
+
+- **Breaking**: `{form name /}` now aligns with standard Latte 2.1 behavior and renders only the opening and closing form tags (begin + end), without the form body. ([#60](https://github.com/jozefizso/BootstrapFormRenderer/issues/60))
+  - Previously, the self-closing `{form name /}` syntax rendered the entire form (begin + errors + body + end) via `$form->render(NULL)`, diverging from Latte 2.1 expectations.
+  - Now, `{form name /}` is equivalent to `{form name}{/form}` and only outputs the `<form>` opening tag and `</form>` closing tag with hidden fields.
+  - **Migration**: Replace `{form name /}` with `{control name}` (recommended) or `{form name}{form errors}{form body}{/form}` for full form rendering.
+  - Removed `findCurrentToken()` reflection method and compiler internals that were used to detect the trailing `/` syntax.
+
 ## v2.1.0
 
 This release targets Nette Framework 2.1 and requires PHP 5.6+.

--- a/tests/KdybyTests/BootstrapFormRenderer/basic/input/self-closing-form.latte
+++ b/tests/KdybyTests/BootstrapFormRenderer/basic/input/self-closing-form.latte
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head><link href="../../bootstrap.min.css" rel="stylesheet"></head>
+<body>
+
+    <div class="container">
+    {form foo /}
+	</div>
+
+</body>
+</html>

--- a/tests/KdybyTests/BootstrapFormRenderer/basic/output/self-closing-form.html
+++ b/tests/KdybyTests/BootstrapFormRenderer/basic/output/self-closing-form.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head><link href="../../bootstrap.min.css" rel="stylesheet"></head>
+<body>
+
+    <div class="container">
+    <form action="" method="post" enctype="multipart/form-data" class="form-horizontal"><div><input type="hidden" name="_token_" id="frm-foo-_token_" value="%a%"></div>
+</form>
+
+	</div>
+
+</body>
+</html>

--- a/tests/KdybyTests/BootstrapFormRenderer/edge/output/multipleFormsInTemplate.html
+++ b/tests/KdybyTests/BootstrapFormRenderer/edge/output/multipleFormsInTemplate.html
@@ -6,13 +6,6 @@
 <body>
 <div class="container">
 	<form action="" method="post" class="form-horizontal">
-		<div id="frm-a-nemam-pair" class="control-group">
-			<label class="control-label" for="frm-a-nemam">Nemam</label>
-
-			<div class="controls">
-				<input type="text" name="nemam" id="frm-a-nemam" value="">
-			</div>
-		</div>
 		<div>
 			<!--[if IE]>
 			<input type=IEbug disabled style="display:none">
@@ -20,13 +13,6 @@
 		</div>
 	</form>
 	<form action="" method="post" class="form-horizontal">
-		<div id="frm-b-mam-pair" class="control-group">
-			<label class="control-label" for="frm-b-mam">Mam</label>
-
-			<div class="controls">
-				<input type="text" name="mam" id="frm-b-mam" value="">
-			</div>
-		</div>
 		<div>
 			<!--[if IE]>
 			<input type=IEbug disabled style="display:none">


### PR DESCRIPTION
In standard Latte 2.1, the self-closing `{form name /}` macro is equivalent to `{form name}{/form}` and renders only the opening and closing form tags (begin + end), not the form body (controls/pairs/errors).

`BootstrapFormRenderer` previously overloaded `{form name /}` to render the entire form via `$form->render(NULL)`, which diverged from Latte 2.1 expectations and created surprising behavior for developers.

Migration:
If your code relies on `{form name /}` rendering the full form, replace with:
- `{control name}` (recommended), or
- `{form name}{form errors}{form body}{/form}`

Fixes #60