### PR TITLE
Use core runtime vars `$_control`/`$_form` when resolving Bootstrap form macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,25 @@ BootstrapFormRenderer works seamlessly with Nette 2.1's built-in translation sys
    ```
 
 
+## Latte Variable Conventions
+
+BootstrapFormRenderer aligns with Latte 2.1 standard runtime variable conventions:
+
+- **`$_control`** - The current component/presenter context (required for form lookup)
+- **`$_form`** - The current form inside `{form}...{/form}` blocks
+
+These variables are automatically provided by Nette 2.1 presenter templates.
+
+### Template Requirements
+
+When rendering forms in your templates:
+- Ensure templates are rendered within a Nette presenter context
+- The `$_control` variable must be available for the `{form name}` macro to resolve forms
+- Inside `{form}...{/form}` blocks, `$_form` provides access to the current form
+
+This is automatically handled in standard Nette 2.1 presenter templates and requires no additional configuration.
+
+
 ## License
 
 You may use BootstrapFormRenderer library under the terms of either

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,21 @@
 
 ### Breaking Changes
 
+#### Form Macros - Latte 2.1 Runtime Variables
+
+- **Breaking**: Form macros now use only Latte 2.1 / Nette 2.1 core runtime variables (`$_control`, `$_form`) and no longer support internal aliases or fallback variables. ([#65](https://github.com/jozefizso/BootstrapFormRenderer/issues/65))
+  - Removed `$__form` internal variable from macro-generated code
+  - Removed fallback resolution for `$control`, `$form`, `$__control`, and `$__form` variables
+  - Form macros now rely exclusively on:
+    - `$_control` for component/form lookup in `{form name}` macros
+    - `$_form` for the current form context inside `{form}...{/form}` blocks
+  - These variables are automatically provided by Nette 2.1 presenter templates
+  - **Migration**:
+    - Custom templates that referenced `$__form` must switch to `$form` or `$_form`
+    - Ensure templates are rendered in a standard Nette 2.1 presenter context that provides `$_control`
+    - Custom renderer templates should pass only `form` and `_form` (not `__form`) to includes
+  - Reference: Aligns with `Nette\Latte\Macros\FormMacros` behavior in Latte 2.1
+
 #### Form Macros - Latte 2.1 Semantics
 
 - **Breaking**: `{form name /}` now aligns with standard Latte 2.1 behavior and renders only the opening and closing form tags (begin + end), without the form body. ([#60](https://github.com/jozefizso/BootstrapFormRenderer/issues/60))

--- a/src/Kdyby/BootstrapFormRenderer/@form.latte
+++ b/src/Kdyby/BootstrapFormRenderer/@form.latte
@@ -24,7 +24,7 @@
 
         {var $controls = $group->controls}
         {if isset($group->template) && $group->template}
-            {include "$group->template", group => $group, controls => $controls, form => $form, _form => $form, __form => $form}
+            {include "$group->template", group => $group, controls => $controls, form => $form, _form => $form}
 
         {else}
             {block #controls}
@@ -46,7 +46,7 @@
                 }
 
                 {if $controlTemplate = $renderer->getControlTemplate($control)}
-                    {include "$controlTemplate", name => $name, description => $description, error => $error, form => $form, _form => $form, __form => $form, attrs => $attrs}
+                    {include "$controlTemplate", name => $name, description => $description, error => $error, form => $form, _form => $form, attrs => $attrs}
 
                 {elseif $renderer->isSubmitButton($control)}
 

--- a/src/Kdyby/BootstrapFormRenderer/Latte/FormMacros.php
+++ b/src/Kdyby/BootstrapFormRenderer/Latte/FormMacros.php
@@ -95,7 +95,7 @@ class FormMacros extends Latte\Macros\MacroSet
 		$node->tokenizer->reset();
 		$node->isEmpty = in_array($word, array('errors', 'body', 'controls', 'buttons'));
 
-		return $writer->write('$form = $__form = $_form = ' . get_called_class() . '::renderFormPart(%node.word, %node.array, get_defined_vars())');
+		return $writer->write('$form = $_form = ' . get_called_class() . '::renderFormPart(%node.word, %node.array, get_defined_vars())');
 	}
 
 
@@ -106,7 +106,7 @@ class FormMacros extends Latte\Macros\MacroSet
 	 */
 	public function macroFormEnd(MacroNode $node, PhpWriter $writer)
 	{
-		return $writer->write('Nette\Latte\Macros\FormMacros::renderFormEnd($__form)');
+		return $writer->write('Nette\Latte\Macros\FormMacros::renderFormEnd($_form)');
 	}
 
 
@@ -123,7 +123,7 @@ class FormMacros extends Latte\Macros\MacroSet
 			throw new CompileException("Missing name in {{$node->name}}.");
 		}
 		$node->tokenizer->reset();
-		return $writer->write('$__form->render($__form[%node.word], %node.array)');
+		return $writer->write('$_form->render($_form[%node.word], %node.array)');
 	}
 
 
@@ -140,7 +140,7 @@ class FormMacros extends Latte\Macros\MacroSet
 			throw new CompileException("Missing name in {{$node->name}}.");
 		}
 		$node->tokenizer->reset();
-		return $writer->write('$__form->render(is_object(%node.word) ? %node.word : $__form->getGroup(%node.word))');
+		return $writer->write('$_form->render(is_object(%node.word) ? %node.word : $_form->getGroup(%node.word))');
 	}
 
 
@@ -157,7 +157,7 @@ class FormMacros extends Latte\Macros\MacroSet
 			throw new CompileException("Missing name in {{$node->name}}.");
 		}
 		$node->tokenizer->reset();
-		return $writer->write('$__form->render($__form[%node.word], %node.array)');
+		return $writer->write('$_form->render($_form[%node.word], %node.array)');
 	}
 
 
@@ -175,18 +175,18 @@ class FormMacros extends Latte\Macros\MacroSet
 			self::renderFormBegin($mode, $args);
 			return $mode;
 
-		} elseif (($control = self::scopeVar($scope, 'control')) && ($form = $control->getComponent($mode, FALSE)) instanceof Form) {
+		} elseif (isset($scope['_control']) && ($form = $scope['_control']->getComponent($mode, FALSE)) instanceof Form) {
 			self::renderFormBegin($form, $args);
 			return $form;
 
-		} elseif (($form = self::scopeVar($scope, 'form')) instanceof Form) {
-			$form->render($mode, $args);
+		} elseif (isset($scope['_form']) && $scope['_form'] instanceof Form) {
+			$scope['_form']->render($mode, $args);
 
 		} else {
-			throw new Nette\InvalidStateException('No instanceof Nette\Forms\Form found in local scope.');
+			throw new Nette\InvalidStateException('No instanceof Nette\Forms\Form found in local scope. Ensure $_control is available in your template.');
 		}
 
-		return $form;
+		return $scope['_form'];
 	}
 
 
@@ -207,18 +207,5 @@ class FormMacros extends Latte\Macros\MacroSet
 
 
 
-	/**
-	 * @param array $scope
-	 * @param string $var
-	 * @return mixed|NULL
-	 */
-	private static function scopeVar(array $scope, $var)
-	{
-		return isset($scope['__' . $var])
-			? $scope['__' . $var]
-			: (isset($scope['_' . $var])
-				? $scope['_' . $var]
-				: (isset($scope[$var]) ? $scope[$var] : NULL));
-	}
 
 }


### PR DESCRIPTION
This change aligns BootstrapFormRenderer's macro implementation with Latte 2.1 core conventions by removing internal aliases and non-standard fallback variables.

- Removed `$__form` internal variable from all macro-generated code
- Removed `scopeVar()` method that provided fallback resolution for `$control`, `$form`, `$__control`, and `$__form` variables
- Form macros now rely exclusively on Latte 2.1 standard runtime variables:
  - `$_control` for component/form lookup in `{form name}` macros
  - `$_form` for current form context inside `{form}...{/form}` blocks

- Custom templates that referenced `$__form` must switch to `$form` or `$_form`
- Ensure templates are rendered in a standard Nette 2.1 presenter context that provides `$_control` (automatic in presenter templates)
- Custom renderer templates should pass only `form` and `_form` parameters to includes (not `__form`)