### PR TITLE
Fix the check for incorrect `<form n:form="frm">` syntax (#80)

### DIFF
--- a/src/Kdyby/BootstrapFormRenderer/Latte/FormMacros.php
+++ b/src/Kdyby/BootstrapFormRenderer/Latte/FormMacros.php
@@ -94,7 +94,7 @@ class FormMacros extends Latte\Macros\MacroSet
 		}
 		$inlineParts = array('errors', 'body', 'controls', 'buttons');
 		if ($node->htmlNode && strtolower($node->htmlNode->name) === 'form' && !in_array($word, $inlineParts, TRUE)) {
-			throw new CompileException('Did you mean <form n:name=...> ?');
+			throw new CompileException("Cannot render {{$node->name}} inside an existing <form> element.");
 		}
 		$node->tokenizer->reset();
 		$node->isEmpty = in_array($word, $inlineParts, TRUE);

--- a/tests/KdybyTests/BootstrapFormRenderer/FormMacrosValidationTest.phpt
+++ b/tests/KdybyTests/BootstrapFormRenderer/FormMacrosValidationTest.phpt
@@ -113,7 +113,7 @@ class FormMacrosValidationTest extends TestCase
 	{
 		Assert::exception(function () {
 			$this->compile('<form>{form myForm}{/form}</form>');
-		}, CompileException::class, 'Did you mean <form n:name=...> ?');
+		}, CompileException::class, 'Cannot render {form} inside an existing <form> element.');
 	}
 
 


### PR DESCRIPTION
Allows the expected syntax with HTML form and Latte control:

```html
<form n:name="frm" class="custom-styling">
  {form body}
</form>
```