### PR TITLE
Remove old compatibility shims 

### DIFF
--- a/src/Kdyby/BootstrapFormRenderer/DI/RendererExtension.php
+++ b/src/Kdyby/BootstrapFormRenderer/DI/RendererExtension.php
@@ -14,19 +14,6 @@ use Kdyby;
 use Nette\DI\Compiler;
 use Nette;
 
-
-
-if (!class_exists('Nette\DI\CompilerExtension')) {
-	class_alias('Nette\Config\CompilerExtension', 'Nette\DI\CompilerExtension');
-	class_alias('Nette\Config\Compiler', 'Nette\DI\Compiler');
-	class_alias('Nette\Config\Helpers', 'Nette\DI\Config\Helpers');
-}
-
-if (isset(Nette\Loaders\NetteLoader::getInstance()->renamed['Nette\Configurator']) || !class_exists('Nette\Configurator')) {
-	unset(Nette\Loaders\NetteLoader::getInstance()->renamed['Nette\Configurator']); // fuck you
-	class_alias('Nette\Config\Configurator', 'Nette\Configurator');
-}
-
 /**
  * @author Filip Procházka <filip@prochazka.su>
  */


### PR DESCRIPTION
Remove `class_alias` calls and `NetteLoader` modifications that were only needed for legacy Nette (pre 2.1) releases. Now targeting Nette 2.1 only.

Fixes #76 