### PR TITLE
Use Latte 2.2 engine `onCompile` callback in unit tests

### DIFF
--- a/tests/KdybyTests/BootstrapFormRenderer/FormMacrosValidationTest.phpt
+++ b/tests/KdybyTests/BootstrapFormRenderer/FormMacrosValidationTest.phpt
@@ -13,8 +13,11 @@
 namespace KdybyTests\FormRenderer;
 
 use Kdyby\BootstrapFormRenderer\Latte\FormMacros;
-use Nette\Latte\CompileException;
-use Nette\Latte\Engine;
+use Latte\CompileException;
+use Latte\Engine;
+use Latte\Loaders\StringLoader;
+use Nette\Bridges\ApplicationLatte\UIMacros;
+use Nette\Bridges\FormsLatte\FormMacros as NetteFormMacros;
 use Tester\Assert;
 use Tester\TestCase;
 
@@ -34,8 +37,13 @@ class FormMacrosValidationTest extends TestCase
 	private function compile($template)
 	{
 		$engine = new Engine();
-		FormMacros::install($engine->getCompiler());
-		return $engine->getCompiler()->compile($engine->getParser()->parse($template));
+		$engine->setLoader(new StringLoader());
+		$engine->onCompile[] = function (Engine $engine) {
+			UIMacros::install($engine->getCompiler());
+			NetteFormMacros::install($engine->getCompiler());
+			FormMacros::install($engine->getCompiler());
+		};
+		return $engine->compile($template);
 	}
 
 


### PR DESCRIPTION
This aligns the template compilation in unit tests with the Nette 2.2 behavior.