### PR TITLE
Change the `BootstrapRenderer` fallback to use `onCompile` callback

### DIFF
--- a/src/Kdyby/BootstrapFormRenderer/BootstrapRenderer.php
+++ b/src/Kdyby/BootstrapFormRenderer/BootstrapRenderer.php
@@ -91,8 +91,10 @@ class BootstrapRenderer extends Nette\Object implements Nette\Forms\IFormRendere
 			} else {
 				$this->template = new FileTemplate();
 				$engine = new Engine();
-				FormMacros::install($engine->getCompiler());
-				\Kdyby\BootstrapFormRenderer\Latte\FormMacros::install($engine->getCompiler());
+				$engine->onCompile[] = function (Engine $engine) {
+					FormMacros::install($engine->getCompiler());
+					\Kdyby\BootstrapFormRenderer\Latte\FormMacros::install($engine->getCompiler());
+				};
 				$this->template->registerFilter($engine);
 			}
 		}


### PR DESCRIPTION
Aligns the Latte 2.2 engine extension with the #75 requirements.