### PR TITLE
Clear the `control` and `presenter` variable on template

### DIFF
--- a/src/Kdyby/BootstrapFormRenderer/BootstrapRenderer.php
+++ b/src/Kdyby/BootstrapFormRenderer/BootstrapRenderer.php
@@ -99,6 +99,13 @@ class BootstrapRenderer extends Nette\Object implements Nette\Forms\IFormRendere
 			}
 		}
 
+		// Prevent Nette UI macros from treating internal renderer templates as presenter views.
+		// Otherwise templates like `@form.latte` may auto-extend the presenter's layout and fail on missing blocks.
+		$this->template->control = NULL;
+		$this->template->_control = NULL;
+		$this->template->presenter = NULL;
+		$this->template->_presenter = NULL;
+
 		if ($this->form !== $form) {
 			$this->form = $form;
 


### PR DESCRIPTION
This clears the `control` and `presenter` variables on a template.

The previous code was removed in commit 077cddbb79a0942d577f90b58429af4a310bfeb2:

```php
$this->template->setParameters(
	array_fill_keys(array('control', '_control', 'presenter', '_presenter'), NULL) +
	array('_form' => $this->form, 'form' => $this->form, 'renderer' => $this)
);
```