### PR TITLE
Switch to individual Nette 2.2 packages

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@ nette:
 ```
 
 ### Breaking Changes
+* **Breaking**: `BootstrapRenderer` requires individual runtime dependencies. This is a potential breaking change.
 * **Breaking**: `BootstrapRenderer` no longer calls `$template->setTranslator($form->getTranslator())`. If you relied on this for `{_...}` / `|translate` in Latte templates, configure Latte translation in your application instead. Form translations still work via `$form->setTranslator($translator)`.
 
 ### Changes

--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,23 @@
 	},
 	"require": {
 		"php": ">=5.6",
-		"nette/nette": "~2.2.0"
+		"latte/latte": "~2.2.0",
+		"nette/application": "~2.2.0",
+		"nette/forms": "~2.2.0",
+		"nette/utils": "~2.2.0"
+	},
+	"suggest": {
+		"nette/di": "Required to register the renderer via DI extension.",
+		"nette/bootstrap": "Required to register the renderer via DI extension."
 	},
 	"require-dev": {
+		"nette/bootstrap": "~2.2.0",
+		"nette/di": "~2.2.0",
+		"nette/http": "~2.2.0",
+		"nette/mail": "~2.2.0",
+		"nette/robot-loader": "~2.2.0",
+		"nette/safe-stream": "~2.2.0",
+		"tracy/tracy": "~2.2.0",
 		"nette/tester": "~2.0.2",
 		"php-parallel-lint/php-parallel-lint": "~1.4.0"
 	},


### PR DESCRIPTION
The `BootstrapFormRenderer` library can be used in projects which require the `nette/nette` meta package, or individual nette packages.

### Simple Nette App

Use BootstrapFormRenderer with the `nette/nette` meta package:

```json
"require": {
    "nette/nette": "~2.2.0",
    "jozefizso/bootstrap-form-renderer": "~2.2.0"
}
```

### Individual Nette Packages

Use tBootstrapFormRenderer with individual Nette components:

```json
"require": {
    "php": ">= 5.6",
    "nette/application": "~2.2.0",
    "nette/bootstrap": "~2.2.0",
    "nette/caching": "~2.2.0",
    "nette/database": "~2.2.0",
    "nette/deprecated": "~2.2.0",
    "nette/di": "~2.2.0",
    "nette/forms": "~2.2.0",
    "nette/http": "~2.2.0",
    "nette/mail": "~2.2.0",
    "nette/robot-loader": "~2.2.0",
	"nette/safe-stream": "~2.2.0",
    "nette/security": "~2.2.0",
    "nette/utils": "~2.2.0",
    "latte/latte": "~2.2.0",
    "tracy/tracy": "~2.2.0"
}
```