### PR TITLE
Use `CallbackFilterIterator` instead of the deprecated `Nette\Iterators\Filter` class

### DIFF
--- a/src/Kdyby/BootstrapFormRenderer/BootstrapRenderer.php
+++ b/src/Kdyby/BootstrapFormRenderer/BootstrapRenderer.php
@@ -16,7 +16,6 @@ use Nette\Application\UI\ITemplate;
 use Nette\Bridges\ApplicationLatte\Template;
 use Nette\Bridges\FormsLatte\FormMacros;
 use Nette\Forms\Controls;
-use Nette\Iterators\Filter;
 use Nette\Utils\Html;
 
 
@@ -294,8 +293,7 @@ class BootstrapRenderer extends Nette\Object implements Nette\Forms\IFormRendere
 	public function findControls(Nette\Forms\Container $container = NULL, $buttons = NULL)
 	{
 		$container = $container ? : $this->form;
-		return new Filter($container->getControls(), function ($control) use ($buttons) {
-			$control = $control instanceof Filter ? $control->current() : $control;
+		return new \CallbackFilterIterator($container->getControls(), function ($control) use ($buttons) {
 			$isButton = $control instanceof Controls\Button || $control instanceof Nette\Forms\ISubmitterControl;
 			return !$control->getOption('rendered')
 				&& !$control instanceof Controls\HiddenField


### PR DESCRIPTION
The `Filter` class was create for old PHP 5.4 runtimes. As this library supports PHP 5.6 and newer, we can use the standard `CallbackFilterIterator` to filter components in the `findControls()` method.

https://www.php.net/manual/en/class.callbackfilteriterator.php