### PR TITLE
Fix `PHP User Notice: Variable $control overwritten in foreach`

### DIFF
--- a/src/Kdyby/BootstrapFormRenderer/@form.latte
+++ b/src/Kdyby/BootstrapFormRenderer/@form.latte
@@ -47,7 +47,7 @@
                 }
 
                 {if $controlTemplate = $renderer->getControlTemplate($controlItem)}
-                    {include "$controlTemplate", name => $name, description => $description, error => $error, form => $form, _form => $form, attrs => $attrs}
+                    {include "$controlTemplate", name => $name, description => $description, error => $error, control => $controlItem, form => $form, _form => $form, attrs => $attrs}
 
                 {elseif $renderer->isSubmitButton($controlItem)}
 


### PR DESCRIPTION
This warning was introduced in Nette 2.4 / Latte 2.4. This issue can be fixed for Nette 2.2, as it improved the code anyway.